### PR TITLE
Fix SteamGuardCode component being visible in source mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ export default class SteamTotpPlugin extends Plugin {
 	override async onload() {
 		await this.loadSettings();
 		this.addSettingTab(new SteamTotpPluginSetingsTab(this.app, this));
-		this.registerEditorExtension(SteamGuardCodePlugin.toExtension());
+		this.registerEditorExtension(SteamGuardCodePlugin.createViewPlugin(this.app));
 		this.registerMarkdownPostProcessor(SteamGuardCodeMarkdownPostProcessor);
 	}
 


### PR DESCRIPTION
This *partially* solves the issue, as the component is still visible after switching to source mode (unless user clicks within the editor)