### PR TITLE
Implement declarative settings API for settings search support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "i18next": "^26.0.3",
     "i18next-cli": "^1.51.5",
     "i18next-cli-plugin-svelte": "^2.0.0",
-    "obsidian": "^1.12.3",
+    "obsidian": "^1.13.1",
     "prettier": "^3.8.1",
     "prettier-plugin-svelte": "^3.5.1",
     "steam-totp": "patch:steam-totp@npm%3A2.1.2#~/.yarn/patches/steam-totp-npm-2.1.2-aaff39ad0a.patch",

--- a/src/lib/settings/tab.ts
+++ b/src/lib/settings/tab.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import i18n from "i18next";
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, PluginSettingTab, Setting, type SettingDefinitionItem } from "obsidian";
 
 import type SimpleSteamAuthPlugin from "../../main.js";
 
@@ -33,6 +33,41 @@ export class SimpleSteamAuthSettingsTab extends PluginSettingTab {
 		this.settings = getSettings();
 	}
 
+	override getSettingDefinitions(): SettingDefinitionItem<keyof SimpleSteamAuthSettings>[] {
+		return [
+			{
+				name: i18n.t("settings.general.showCopyButton.name"),
+				desc: i18n.t("settings.general.showCopyButton.desc"),
+				control: { type: "toggle", key: "showCopyButton" }
+			},
+			{
+				name: i18n.t("settings.general.showCodeByDefault.name"),
+				desc: this.getShowCodeByDefaultDesc(),
+				control: { type: "toggle", key: "showCodeByDefault" }
+			}
+		];
+	}
+
+	override getControlValue(key: keyof SimpleSteamAuthSettings): unknown {
+		return this.settings[key];
+	}
+
+	override async setControlValue(
+		key: keyof SimpleSteamAuthSettings,
+		value: unknown
+	): Promise<void> {
+		switch (key) {
+			case "showCopyButton":
+			case "showCodeByDefault":
+				this.settings[key] = value as boolean;
+				break;
+		}
+		await this.plugin.saveSettings();
+	}
+
+	/**
+	 * @deprecated Fallback for Obsidian versions older than 1.13.0. Use {@link getSettingDefinitions} instead.
+	 */
 	override display() {
 		this.containerEl.empty();
 		this.addShowCopyButton();
@@ -54,26 +89,28 @@ export class SimpleSteamAuthSettingsTab extends PluginSettingTab {
 	private addShowCodeByDefault() {
 		new Setting(this.containerEl)
 			.setName(i18n.t("settings.general.showCodeByDefault.name"))
-			.setDesc(
-				createFragment((descEl) => {
-					const div = descEl.createDiv();
-					div.createSpan({
-						text: i18n.t("settings.general.showCodeByDefault.desc.span.0")
-					});
-					div.createEl("br");
-					div.createEl("b", {
-						text: i18n.t("settings.general.showCodeByDefault.desc.b.0")
-					});
-					div.createSpan({
-						text: i18n.t("settings.general.showCodeByDefault.desc.span.1")
-					});
-				})
-			)
+			.setDesc(this.getShowCodeByDefaultDesc())
 			.addToggle((toggle) =>
 				toggle.setValue(this.settings.showCodeByDefault).onChange(async (value) => {
 					this.settings.showCodeByDefault = value;
 					await this.plugin.saveSettings();
 				})
 			);
+	}
+
+	private getShowCodeByDefaultDesc(): DocumentFragment {
+		return createFragment((descEl) => {
+			const div = descEl.createDiv();
+			div.createSpan({
+				text: i18n.t("settings.general.showCodeByDefault.desc.span.0")
+			});
+			div.createEl("br");
+			div.createEl("b", {
+				text: i18n.t("settings.general.showCodeByDefault.desc.b.0")
+			});
+			div.createSpan({
+				text: i18n.t("settings.general.showCodeByDefault.desc.span.1")
+			});
+		});
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2790,7 +2790,7 @@ __metadata:
     i18next: "npm:^26.0.3"
     i18next-cli: "npm:^1.51.5"
     i18next-cli-plugin-svelte: "npm:^2.0.0"
-    obsidian: "npm:^1.12.3"
+    obsidian: "npm:^1.13.1"
     prettier: "npm:^3.8.1"
     prettier-plugin-svelte: "npm:^3.5.1"
     steam-totp: "patch:steam-totp@npm%3A2.1.2#~/.yarn/patches/steam-totp-npm-2.1.2-aaff39ad0a.patch"
@@ -2804,16 +2804,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"obsidian@npm:^1.12.3":
-  version: 1.12.3
-  resolution: "obsidian@npm:1.12.3"
+"obsidian@npm:^1.13.1":
+  version: 1.13.1
+  resolution: "obsidian@npm:1.13.1"
   dependencies:
     "@types/codemirror": "npm:5.60.8"
     moment: "npm:2.29.4"
   peerDependencies:
     "@codemirror/state": 6.5.0
     "@codemirror/view": 6.38.6
-  checksum: 10c0/17786c4740e147ce6805dc93d3bd62750e87993bc6c21df519f1fdc8fc6cdc61ac478d78bf299f0f512bf0d53a1c2f4ff92b0905a82e472fccd9b10880b564fb
+  checksum: 10c0/cc7bf4de68c36edfd7e3a348b45c8919d01bc6fb04b1f03fae74092156bf78add092f0f94c3885599fefbb3a83740630360044a1d899bd299c2016d345311521
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> - **Warning**: This PluginSettingTab does not implement getSettingDefinitions(); its settings will not appear in Obsidian's settings search for users on 1.13.0 or later. Consider adopting the declarative settings API.
> - src/lib/settings/tab.ts:26

From https://community.obsidian.md/plugins/simple-steam-auth#scorecard

To be merged once v1.13 is out